### PR TITLE
지출 생성 & 수정 API

### DIFF
--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -16,4 +16,5 @@ services:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
     # <로컬:컨테이너> 볼륨 마운팅
     volumes:
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
       - ./database/postgresql:/var/lib/postgresql/data

--- a/init.sql
+++ b/init.sql
@@ -1,0 +1,2 @@
+-- 프로젝트 데이터베이스 생성
+CREATE DATABASE budget_keeper;

--- a/src/api/expense/dto/create-expense-request-body.dto.ts
+++ b/src/api/expense/dto/create-expense-request-body.dto.ts
@@ -1,0 +1,41 @@
+import {
+  IsDate,
+  IsNumber,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
+import { CreateExpenseResource } from './create-expense-resource.dto';
+import { Type } from 'class-transformer';
+
+export class CreateExpenseRequestBody {
+  @IsNumber()
+  categoryId: number;
+
+  @IsString()
+  @MaxLength(100)
+  content: string;
+
+  @IsNumber()
+  @Min(10) // 10원 이상
+  @Max(2000000000) // 20억 이하
+  amount: number;
+
+  @Type(() => Date)
+  @IsDate() // YYYY-MM-DD
+  expenseDate: Date;
+
+  // TODO: Mapper 클래스로 만들어보기
+  toCreateExpenseResource(userId: string) {
+    const createExpenseResource = new CreateExpenseResource();
+
+    createExpenseResource.userId = userId;
+    createExpenseResource.categoryId = this.categoryId;
+    createExpenseResource.content = this.content;
+    createExpenseResource.amount = this.amount;
+    createExpenseResource.expenseDate = this.expenseDate;
+
+    return createExpenseResource;
+  }
+}

--- a/src/api/expense/dto/create-expense-resource.dto.ts
+++ b/src/api/expense/dto/create-expense-resource.dto.ts
@@ -1,0 +1,7 @@
+export class CreateExpenseResource {
+  userId: string;
+  categoryId: number;
+  content: string;
+  amount: number;
+  expenseDate: Date;
+}

--- a/src/api/expense/dto/create-expense-response-data.dto.ts
+++ b/src/api/expense/dto/create-expense-response-data.dto.ts
@@ -7,6 +7,21 @@ export class CreateExpenseResponseData {
   id: number;
 
   @Expose()
+  categoryId: number;
+
+  @Expose()
+  content: string;
+
+  @Expose()
+  amount: number;
+
+  @Expose()
+  expenseDate: Date;
+
+  @Expose()
+  isExcluded: boolean;
+
+  @Expose()
   createdAt: Date;
 
   static of(expense: Expense): CreateExpenseResponseData {

--- a/src/api/expense/dto/create-expense-response-data.dto.ts
+++ b/src/api/expense/dto/create-expense-response-data.dto.ts
@@ -1,0 +1,15 @@
+import { Exclude, Expose, plainToInstance } from 'class-transformer';
+import { Expense } from '../../../entity/expense.entity';
+
+@Exclude()
+export class CreateExpenseResponseData {
+  @Expose()
+  id: number;
+
+  @Expose()
+  createdAt: Date;
+
+  static of(expense: Expense): CreateExpenseResponseData {
+    return plainToInstance(CreateExpenseResponseData, expense);
+  }
+}

--- a/src/api/expense/dto/create-expense.dto.ts
+++ b/src/api/expense/dto/create-expense.dto.ts
@@ -1,0 +1,1 @@
+export class CreateExpenseDto {}

--- a/src/api/expense/dto/create-expense.dto.ts
+++ b/src/api/expense/dto/create-expense.dto.ts
@@ -1,1 +1,0 @@
-export class CreateExpenseDto {}

--- a/src/api/expense/dto/update-expense-request-body.dto.ts
+++ b/src/api/expense/dto/update-expense-request-body.dto.ts
@@ -1,0 +1,63 @@
+import {
+  IsBoolean,
+  IsDate,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { UpdateExpenseResource } from './update-expense-resource.dto';
+
+export class UpdateExpenseRequestBody {
+  @IsNumber()
+  @IsOptional()
+  categoryId?: number;
+
+  @IsString()
+  @MaxLength(100)
+  @IsOptional()
+  content?: string;
+
+  @IsNumber()
+  @Min(10) // 10원 이상
+  @Max(2000000000) // 20억 이하
+  @IsOptional()
+  amount?: number;
+
+  @Type(() => Date)
+  @IsDate() // YYYY-MM-DD
+  @IsOptional()
+  expenseDate?: Date;
+
+  @IsBoolean()
+  @IsOptional()
+  isExcluded?: boolean;
+
+  // TODO: Mapper 클래스로 만들어보기
+  toUpdateExpenseResource() {
+    const updateExpenseResource = new UpdateExpenseResource();
+
+    if (this.categoryId) {
+      updateExpenseResource.categoryId = this.categoryId;
+    }
+    if (this.content !== undefined) {
+      // ''(빈 문자열)로 받아도 변경 가능
+      updateExpenseResource.content = this.content;
+    }
+    if (this.amount) {
+      updateExpenseResource.amount = this.amount;
+    }
+    if (this.expenseDate) {
+      updateExpenseResource.expenseDate = this.expenseDate;
+    }
+    if (this.isExcluded !== undefined) {
+      // true 또는 false로 값이 오면 변경 가능
+      updateExpenseResource.isExcluded = this.isExcluded;
+    }
+
+    return updateExpenseResource;
+  }
+}

--- a/src/api/expense/dto/update-expense-resource.dto.ts
+++ b/src/api/expense/dto/update-expense-resource.dto.ts
@@ -1,0 +1,7 @@
+export class UpdateExpenseResource {
+  categoryId?: number;
+  content?: string;
+  amount?: number;
+  expenseDate?: Date;
+  isExcluded?: boolean;
+}

--- a/src/api/expense/dto/update-expense-response-body.dto.ts
+++ b/src/api/expense/dto/update-expense-response-body.dto.ts
@@ -1,0 +1,40 @@
+import { Exclude, Expose, plainToInstance, Type } from 'class-transformer';
+import { Expense } from '../../../entity/expense.entity';
+import {
+  IsBoolean,
+  IsDate,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
+
+@Exclude()
+export class UpdateExpenseResponseData {
+  @Expose()
+  id: number;
+
+  @Expose()
+  categoryId: number;
+
+  @Expose()
+  content: string;
+
+  @Expose()
+  amount: number;
+
+  @Expose()
+  expenseDate: Date;
+
+  @Expose()
+  isExcluded: boolean;
+
+  @Expose()
+  updatedAt: Date;
+
+  static of(expense: Expense): UpdateExpenseResponseData {
+    return plainToInstance(UpdateExpenseResponseData, expense);
+  }
+}

--- a/src/api/expense/dto/update-expense.dto.ts
+++ b/src/api/expense/dto/update-expense.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateExpenseDto } from './create-expense.dto';
+
+export class UpdateExpenseDto extends PartialType(CreateExpenseDto) {}

--- a/src/api/expense/dto/update-expense.dto.ts
+++ b/src/api/expense/dto/update-expense.dto.ts
@@ -1,5 +1,0 @@
-import { PartialType } from '@nestjs/mapped-types';
-
-// export class UpdateExpenseDto extends PartialType(
-//   CreateExpenseRequestBodyDto,
-// ) {}

--- a/src/api/expense/dto/update-expense.dto.ts
+++ b/src/api/expense/dto/update-expense.dto.ts
@@ -1,4 +1,5 @@
 import { PartialType } from '@nestjs/mapped-types';
-import { CreateExpenseDto } from './create-expense.dto';
 
-export class UpdateExpenseDto extends PartialType(CreateExpenseDto) {}
+// export class UpdateExpenseDto extends PartialType(
+//   CreateExpenseRequestBodyDto,
+// ) {}

--- a/src/api/expense/expense.controller.ts
+++ b/src/api/expense/expense.controller.ts
@@ -1,0 +1,42 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+} from '@nestjs/common';
+import { ExpenseService } from './service/expense.service';
+import { CreateExpenseDto } from './dto/create-expense.dto';
+import { UpdateExpenseDto } from './dto/update-expense.dto';
+
+@Controller('expenses')
+export class ExpenseController {
+  constructor(private readonly expenseService: ExpenseService) {}
+
+  @Post()
+  create(@Body() createExpenseDto: CreateExpenseDto) {
+    return 'POST /expenses';
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateExpenseDto: UpdateExpenseDto) {
+    return 'PATCH /expenses/:id';
+  }
+
+  @Get()
+  findAll() {
+    return 'GET /expenses';
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return 'GET /expenses/:id';
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return 'DELETE /expenses/:id';
+  }
+}

--- a/src/api/expense/expense.controller.ts
+++ b/src/api/expense/expense.controller.ts
@@ -11,14 +11,15 @@ import {
 } from '@nestjs/common';
 
 import { CreateExpenseRequestBody } from './dto/create-expense-request-body.dto';
-// import { UpdateExpenseDto } from './dto/update-expense.dto';
+import { CreateExpenseResponseData } from './dto/create-expense-response-data.dto';
+import { UpdateExpenseResponseData } from './dto/update-expense-response-body.dto';
+import { UpdateExpenseRequestBody } from './dto/update-expense-request-body.dto';
 
 import { ExpenseService } from './service/expense.service';
 
-import { JwtAuthGuard } from '../../shared/guard/jwt-auth.guard';
-import { RequestWithUser } from '../../shared/interface/request-with-user.interfact';
 import { SuccessMessage } from '../../shared/enum/success-message.enum';
-import { CreateExpenseResponseData } from './dto/create-expense-response-data.dto';
+import { RequestWithUser } from '../../shared/interface/request-with-user.interfact';
+import { JwtAuthGuard } from '../../shared/guard/jwt-auth.guard';
 
 @UseGuards(JwtAuthGuard)
 @Controller('expenses')
@@ -39,10 +40,25 @@ export class ExpenseController {
     };
   }
 
-  // @Patch(':id')
-  // update(@Param('id') id: number, @Body() updateExpenseDto: UpdateExpenseDto) {
-  //   return 'PATCH /expenses/:id';
-  // }
+  @Patch(':id')
+  async updateExpense(
+    @Param('id') id: number,
+    @Body() dto: UpdateExpenseRequestBody,
+  ) {
+    // 지출 수정
+    await this.expenseService.updateExpenseById(
+      id,
+      dto.toUpdateExpenseResource(),
+    );
+
+    // 수정된 지출 조회
+    const expense = await this.expenseService.getExpenseById(id);
+
+    return {
+      message: SuccessMessage.EXPENSE_UPDATE,
+      data: UpdateExpenseResponseData.of(expense),
+    };
+  }
 
   @Get()
   findAll() {

--- a/src/api/expense/expense.controller.ts
+++ b/src/api/expense/expense.controller.ts
@@ -6,24 +6,43 @@ import {
   Patch,
   Param,
   Delete,
+  UseGuards,
+  Req,
 } from '@nestjs/common';
-import { ExpenseService } from './service/expense.service';
-import { CreateExpenseDto } from './dto/create-expense.dto';
-import { UpdateExpenseDto } from './dto/update-expense.dto';
 
+import { CreateExpenseRequestBody } from './dto/create-expense-request-body.dto';
+// import { UpdateExpenseDto } from './dto/update-expense.dto';
+
+import { ExpenseService } from './service/expense.service';
+
+import { JwtAuthGuard } from '../../shared/guard/jwt-auth.guard';
+import { RequestWithUser } from '../../shared/interface/request-with-user.interfact';
+import { SuccessMessage } from '../../shared/enum/success-message.enum';
+import { CreateExpenseResponseData } from './dto/create-expense-response-data.dto';
+
+@UseGuards(JwtAuthGuard)
 @Controller('expenses')
 export class ExpenseController {
   constructor(private readonly expenseService: ExpenseService) {}
 
   @Post()
-  create(@Body() createExpenseDto: CreateExpenseDto) {
-    return 'POST /expenses';
+  async createExpense(
+    @Req() req: RequestWithUser,
+    @Body() dto: CreateExpenseRequestBody,
+  ) {
+    const expense = await this.expenseService.createExpenseData(
+      dto.toCreateExpenseResource(req.user.id),
+    );
+    return {
+      message: SuccessMessage.EXPENSE_CREATE,
+      data: CreateExpenseResponseData.of(expense),
+    };
   }
 
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updateExpenseDto: UpdateExpenseDto) {
-    return 'PATCH /expenses/:id';
-  }
+  // @Patch(':id')
+  // update(@Param('id') id: number, @Body() updateExpenseDto: UpdateExpenseDto) {
+  //   return 'PATCH /expenses/:id';
+  // }
 
   @Get()
   findAll() {

--- a/src/api/expense/expense.controller.ts
+++ b/src/api/expense/expense.controller.ts
@@ -20,6 +20,7 @@ import { ExpenseService } from './service/expense.service';
 import { SuccessMessage } from '../../shared/enum/success-message.enum';
 import { RequestWithUser } from '../../shared/interface/request-with-user.interfact';
 import { JwtAuthGuard } from '../../shared/guard/jwt-auth.guard';
+import { OwnExpenseGuard } from './guard/own-expense.guard';
 
 @UseGuards(JwtAuthGuard)
 @Controller('expenses')
@@ -40,6 +41,7 @@ export class ExpenseController {
     };
   }
 
+  @UseGuards(OwnExpenseGuard)
   @Patch(':id')
   async updateExpense(
     @Param('id') id: number,
@@ -65,11 +67,13 @@ export class ExpenseController {
     return 'GET /expenses';
   }
 
+  @UseGuards(OwnExpenseGuard)
   @Get(':id')
   findOne(@Param('id') id: string) {
     return 'GET /expenses/:id';
   }
 
+  @UseGuards(OwnExpenseGuard)
   @Delete(':id')
   remove(@Param('id') id: string) {
     return 'DELETE /expenses/:id';

--- a/src/api/expense/expense.module.ts
+++ b/src/api/expense/expense.module.ts
@@ -4,11 +4,11 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ExpenseService } from './service/expense.service';
 import { ExpenseController } from './expense.controller';
 
-import { Budget } from '../../entity/budget.entity';
 import { Expense } from '../../entity/expense.entity';
+import { Category } from '../../entity/category.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Budget, Expense])],
+  imports: [TypeOrmModule.forFeature([Expense, Category])],
   controllers: [ExpenseController],
   providers: [ExpenseService],
 })

--- a/src/api/expense/expense.module.ts
+++ b/src/api/expense/expense.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ExpenseService } from './service/expense.service';
+import { ExpenseController } from './expense.controller';
+
+@Module({
+  controllers: [ExpenseController],
+  providers: [ExpenseService],
+})
+export class ExpenseModule {}

--- a/src/api/expense/expense.module.ts
+++ b/src/api/expense/expense.module.ts
@@ -1,8 +1,14 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
 import { ExpenseService } from './service/expense.service';
 import { ExpenseController } from './expense.controller';
 
+import { Budget } from '../../entity/budget.entity';
+import { Expense } from '../../entity/expense.entity';
+
 @Module({
+  imports: [TypeOrmModule.forFeature([Budget, Expense])],
   controllers: [ExpenseController],
   providers: [ExpenseService],
 })

--- a/src/api/expense/expense.module.ts
+++ b/src/api/expense/expense.module.ts
@@ -6,10 +6,12 @@ import { ExpenseController } from './expense.controller';
 
 import { Expense } from '../../entity/expense.entity';
 import { Category } from '../../entity/category.entity';
+import { ExpenseLib } from './service/expense.lib';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Expense, Category])],
   controllers: [ExpenseController],
-  providers: [ExpenseService],
+  providers: [ExpenseService, ExpenseLib],
+  exports: [ExpenseLib],
 })
 export class ExpenseModule {}

--- a/src/api/expense/guard/own-expense.guard.ts
+++ b/src/api/expense/guard/own-expense.guard.ts
@@ -1,0 +1,35 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { RequestWithUser } from '../../../shared/interface/request-with-user.interfact';
+import { ExpenseLib } from '../service/expense.lib';
+import { FailMessage } from '../../../shared/enum/fail-message.enum';
+
+/**
+ * 지출에 대한 권한 검사를 하는 가드
+ * 사용자 본인이 생성한 지출에 대해서만 접근 가능
+ */
+@Injectable()
+export class OwnExpenseGuard implements CanActivate {
+  constructor(
+    // TODO: databaseService로 분리
+    private readonly expenseLib: ExpenseLib,
+  ) {}
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<RequestWithUser>();
+
+    const user = request.user;
+    const expenseId = parseInt(request.params.id);
+
+    const isOwnExpense = await this.expenseLib.isOwnExpense(expenseId, user.id);
+
+    if (!isOwnExpense) {
+      // NOTE: 보안 상의 이유로 403이 아니라 404로 응답합니다.
+      throw new NotFoundException(FailMessage.EXPENSE_NOT_FOUND);
+    }
+    return true;
+  }
+}

--- a/src/api/expense/service/expense.lib.ts
+++ b/src/api/expense/service/expense.lib.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { Expense } from '../../../entity/expense.entity';
+
+@Injectable()
+export class ExpenseLib {
+  constructor(
+    @InjectRepository(Expense)
+    private readonly expenseRepo: Repository<Expense>,
+  ) {}
+
+  async isOwnExpense(id: number, userId: string): Promise<boolean> {
+    return !!(await this.expenseRepo.findOneBy({ id, userId }));
+  }
+}

--- a/src/api/expense/service/expense.service.ts
+++ b/src/api/expense/service/expense.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ExpenseService {}

--- a/src/api/expense/service/expense.service.ts
+++ b/src/api/expense/service/expense.service.ts
@@ -1,4 +1,33 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { CreateExpenseResource } from '../dto/create-expense-resource.dto';
+
+import { Expense } from '../../../entity/expense.entity';
+import { Budget } from '../../../entity/budget.entity';
+import { BudgetMonth } from '../../../shared/enum/budget-month.enum';
 
 @Injectable()
-export class ExpenseService {}
+export class ExpenseService {
+  constructor(
+    @InjectRepository(Expense)
+    private readonly expenseRepo: Repository<Expense>,
+  ) {}
+
+  async createExpenseData(
+    createExpenseResource: CreateExpenseResource,
+  ): Promise<Expense> {
+    return this.expenseRepo.save(
+      this.expenseRepo.create({ ...createExpenseResource }),
+    );
+  }
+
+  extractMonth(date: Date) {
+    return Object.values(BudgetMonth)[date.getUTCMonth()];
+  }
+
+  extractYear(date: Date) {
+    return date.getUTCFullYear().toString();
+  }
+}

--- a/src/api/expense/service/expense.service.ts
+++ b/src/api/expense/service/expense.service.ts
@@ -18,26 +18,30 @@ export class ExpenseService {
     private readonly categoryRepo: Repository<Expense>,
   ) {}
 
-  async createExpenseData(
-    createExpenseResource: CreateExpenseResource,
-  ): Promise<Expense> {
+  async createExpenseData(dto: CreateExpenseResource): Promise<Expense> {
     const category = await this.categoryRepo.findOneBy({
-      id: createExpenseResource.categoryId,
+      id: dto.categoryId,
     });
 
     if (!category) {
       throw new BadRequestException(FailMessage.EXPENSE_INVALID_CATEGORY_ID);
     }
 
-    return this.expenseRepo.save(
-      this.expenseRepo.create({ ...createExpenseResource }),
-    );
+    return this.expenseRepo.save(this.expenseRepo.create(dto));
   }
 
   async updateExpenseById(
     id: number,
     dto: UpdateExpenseResource,
   ): Promise<void> {
+    const category = await this.categoryRepo.findOneBy({
+      id: dto.categoryId,
+    });
+
+    if (!category) {
+      throw new BadRequestException(FailMessage.EXPENSE_INVALID_CATEGORY_ID);
+    }
+
     await this.expenseRepo.update({ id }, dto);
   }
 

--- a/src/api/expense/service/expense.service.ts
+++ b/src/api/expense/service/expense.service.ts
@@ -1,23 +1,34 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
 import { CreateExpenseResource } from '../dto/create-expense-resource.dto';
 
 import { Expense } from '../../../entity/expense.entity';
-import { Budget } from '../../../entity/budget.entity';
 import { BudgetMonth } from '../../../shared/enum/budget-month.enum';
+import { Category } from '../../../entity/category.entity';
+import { FailMessage } from '../../../shared/enum/fail-message.enum';
 
 @Injectable()
 export class ExpenseService {
   constructor(
     @InjectRepository(Expense)
     private readonly expenseRepo: Repository<Expense>,
+    @InjectRepository(Category)
+    private readonly categoryRepo: Repository<Expense>,
   ) {}
 
   async createExpenseData(
     createExpenseResource: CreateExpenseResource,
   ): Promise<Expense> {
+    const category = await this.categoryRepo.findOneBy({
+      id: createExpenseResource.categoryId,
+    });
+
+    if (!category) {
+      throw new BadRequestException(FailMessage.EXPENSE_INVALID_CATEGORY_ID);
+    }
+
     return this.expenseRepo.save(
       this.expenseRepo.create({ ...createExpenseResource }),
     );

--- a/src/api/expense/service/expense.service.ts
+++ b/src/api/expense/service/expense.service.ts
@@ -5,9 +5,9 @@ import { Repository } from 'typeorm';
 import { CreateExpenseResource } from '../dto/create-expense-resource.dto';
 
 import { Expense } from '../../../entity/expense.entity';
-import { BudgetMonth } from '../../../shared/enum/budget-month.enum';
 import { Category } from '../../../entity/category.entity';
 import { FailMessage } from '../../../shared/enum/fail-message.enum';
+import { UpdateExpenseResource } from '../dto/update-expense-resource.dto';
 
 @Injectable()
 export class ExpenseService {
@@ -34,11 +34,14 @@ export class ExpenseService {
     );
   }
 
-  extractMonth(date: Date) {
-    return Object.values(BudgetMonth)[date.getUTCMonth()];
+  async updateExpenseById(
+    id: number,
+    dto: UpdateExpenseResource,
+  ): Promise<void> {
+    await this.expenseRepo.update({ id }, dto);
   }
 
-  extractYear(date: Date) {
-    return date.getUTCFullYear().toString();
+  getExpenseById(id: number): Promise<Expense> {
+    return this.expenseRepo.findOneBy({ id });
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -41,7 +41,6 @@ import { ExpenseModule } from './api/expense/expense.module';
           entities: [path.join(__dirname, '/entity/*.entity{.ts,.js}')],
           logging: serverConfig.nodeEnv === NodeEnv.DEV,
           namingStrategy: new SnakeNamingStrategy(),
-          timezone: 'Asia/Seoul',
         };
       },
     }),

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import { IServerConfig } from './shared/interface/server-config.interface';
 import { AuthModule } from './api/auth/auth.module';
 import { CategoryModule } from './api/category/category.module';
 import { BudgetModule } from './api/budget/budget.module';
+import { ExpenseModule } from './api/expense/expense.module';
 
 @Module({
   imports: [
@@ -47,6 +48,7 @@ import { BudgetModule } from './api/budget/budget.module';
     AuthModule,
     CategoryModule,
     BudgetModule,
+    ExpenseModule,
   ],
   providers: [
     {

--- a/src/database/seeding/data-source.ts
+++ b/src/database/seeding/data-source.ts
@@ -25,5 +25,4 @@ export default new DataSource({
   seeds: ['src/database/seeding/seeds/**/*{.ts,.js}'],
   logging: process.env.NODE_ENV === NodeEnv.DEV,
   namingStrategy: new SnakeNamingStrategy(),
-  timezone: 'Asia/Seoul',
 } as DataSourceOptions & SeederOptions);

--- a/src/entity/expense.entity.ts
+++ b/src/entity/expense.entity.ts
@@ -2,7 +2,6 @@ import {
   Check,
   Column,
   CreateDateColumn,
-  DeleteDateColumn,
   Entity,
   JoinColumn,
   ManyToOne,
@@ -11,7 +10,7 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 import { User } from './user.entity';
-import { BudgetMonth } from '../shared/enum/budget-month.enum';
+import { Budget } from './budget.entity';
 import { Category } from './category.entity';
 
 @Entity('expenses')
@@ -24,9 +23,22 @@ export class Expense {
   @JoinColumn({ name: 'user_id' })
   user: User;
 
+  @Column()
+  userId: string;
+
+  @ManyToOne(() => Budget)
+  @JoinColumn({ name: 'budget_id' })
+  budget: Budget;
+
+  @Column()
+  budgetId: number;
+
   @OneToOne(() => Category, { nullable: false })
   @JoinColumn({ name: 'category_id' })
   category: Category;
+
+  @Column()
+  categoryId: number;
 
   @Column({ type: 'varchar', length: 100 })
   content: string;
@@ -37,18 +49,12 @@ export class Expense {
   @Column({ type: 'boolean', default: false })
   isExcluded: boolean;
 
-  @Column({ type: 'varchar', length: 10 })
-  year: string;
-
-  @Column({ type: 'varchar', length: 10 })
-  month: BudgetMonth;
+  @Column({ type: 'timestamp with time zone' })
+  expenseDate: Date;
 
   @CreateDateColumn({ type: 'timestamp with time zone' })
   createdAt: Date;
 
   @UpdateDateColumn({ type: 'timestamp with time zone', nullable: true })
   updatedAt: Date;
-
-  @DeleteDateColumn({ type: 'timestamp with time zone', nullable: true })
-  deletedAt: Date;
 }

--- a/src/entity/expense.entity.ts
+++ b/src/entity/expense.entity.ts
@@ -26,14 +26,7 @@ export class Expense {
   @Column()
   userId: string;
 
-  @ManyToOne(() => Budget)
-  @JoinColumn({ name: 'budget_id' })
-  budget: Budget;
-
-  @Column()
-  budgetId: number;
-
-  @OneToOne(() => Category, { nullable: false })
+  @ManyToOne(() => Category, { nullable: false })
   @JoinColumn({ name: 'category_id' })
   category: Category;
 

--- a/src/shared/enum/fail-message.enum.ts
+++ b/src/shared/enum/fail-message.enum.ts
@@ -6,4 +6,5 @@ export enum FailMessage {
   USER_EMAIL_DO_NOT_EXIST = '존재하지 않는 이메일입니다.',
   USER_PASSWORD_IS_WRONG = '비밀번호가 일치하지 않습니다.',
   EXPENSE_INVALID_CATEGORY_ID = '카테고리 ID가 유효하지 않습니다.',
+  EXPENSE_NOT_FOUND = '지출이 존재하지 않습니다.',
 }

--- a/src/shared/enum/fail-message.enum.ts
+++ b/src/shared/enum/fail-message.enum.ts
@@ -5,4 +5,5 @@ export enum FailMessage {
   USER_EMAIL_IS_DUPLICATED = '사용할 수 없는 이메일입니다.',
   USER_EMAIL_DO_NOT_EXIST = '존재하지 않는 이메일입니다.',
   USER_PASSWORD_IS_WRONG = '비밀번호가 일치하지 않습니다.',
+  EXPENSE_INVALID_CATEGORY_ID = '카테고리 ID가 유효하지 않습니다.',
 }

--- a/src/shared/enum/success-message.enum.ts
+++ b/src/shared/enum/success-message.enum.ts
@@ -6,4 +6,5 @@ export enum SuccessMessage {
   BUDGET_SET_MONTHLY = '월별 예산 설정 성공했습니다.',
   BUDGET_GET_RECOMMENDATION = '월별 예산 추천 성공했습니다.',
   EXPENSE_CREATE = '지출 생성 성공했습니다.',
+  EXPENSE_UPDATE = '지출 수정 성공했습니다.',
 }

--- a/src/shared/enum/success-message.enum.ts
+++ b/src/shared/enum/success-message.enum.ts
@@ -5,4 +5,5 @@ export enum SuccessMessage {
   CATEGORY_GET_ALL = '카테고리 목록 조회 성공했습니다.',
   BUDGET_SET_MONTHLY = '월별 예산 설정 성공했습니다.',
   BUDGET_GET_RECOMMENDATION = '월별 예산 추천 성공했습니다.',
+  EXPENSE_CREATE = '지출 생성 성공했습니다.',
 }

--- a/test/unit/expense.controller.spec.ts
+++ b/test/unit/expense.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExpenseController } from '../../src/api/expense/expense.controller';
+import { ExpenseService } from '../../src/api/expense/service/expense.service';
+
+describe('ExpenseController', () => {
+  let controller: ExpenseController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ExpenseController],
+      providers: [ExpenseService],
+    }).compile();
+
+    controller = module.get<ExpenseController>(ExpenseController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/test/unit/expense.service.spec.ts
+++ b/test/unit/expense.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExpenseService } from '../../src/api/expense/service/expense.service';
+
+describe('ExpenseService', () => {
+  let service: ExpenseService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ExpenseService],
+    }).compile();
+
+    service = module.get<ExpenseService>(ExpenseService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});


### PR DESCRIPTION
## 🚀 이슈 번호
https://github.com/dawwson/budget-keeper-be/issues/11#issue-1989468468
<br>

## 💡 변경 이유
- 기능 추가
<br>

## 🔑 주요 변경사항
- 지출 생성 & 수정 API 완성
  - `dto` 네이밍 설정
    - 요청, 응답 : `{동작}_{자원}RequestBody`, `{동작}_{자원}RequestParam`, `{동작}_{자원}ResponseData`
    - 비즈니스 로직 : `{동작}_{자원}Resource`
  - `dto` 변환 with `class-transformer`
    - `controller` -> `service` : `request dto` 내부에서 진행
    - `entity` -> `response` : `response dto static` 함수로 진행
  - 권한 검증하는 가드 추가
    - /expenses 엔드포인트 여러 개에 걸쳐 동일한 검사 로직이 반복될 것이기 때문에 별도의 클래스에서 분리함 => AOP? 라고 볼 수 있는지 잘 모르겠다...🤔
## 향후 리팩터 방향
- [ ]  별도의 Mapper 클래스 안에서 dto 변환하여 controller가 Mapper 클래스에만 의존할 수 있도록 수정.
- [ ] dto 네이밍에서 'dto'를 빼버리기 => 파일명만 봐도 이게 dto인지 분간 가능하기 때문임.

<br>

## 📷 테스트 결과
- 생성 API
<img width="890" alt="image" src="https://github.com/dawwson/budget-keeper-be/assets/45624238/f290c492-aee9-4493-9f66-ea818e44ddab">

- 수정 API
<img width="893" alt="image" src="https://github.com/dawwson/budget-keeper-be/assets/45624238/18ab487b-baf4-47c9-93af-bdcf6e41f015">

