### PR TITLE
지출 목록 조회 & 지출 상세 조회 API

### DIFF
--- a/src/api/expense/dto/create-expense-request-body.dto.ts
+++ b/src/api/expense/dto/create-expense-request-body.dto.ts
@@ -23,7 +23,7 @@ export class CreateExpenseRequestBody {
   amount: number;
 
   @Type(() => Date)
-  @IsDate() // YYYY-MM-DD
+  @IsDate()
   expenseDate: Date;
 
   // TODO: Mapper 클래스로 만들어보기

--- a/src/api/expense/dto/get-categories-with-total-amount-condition.dto.ts
+++ b/src/api/expense/dto/get-categories-with-total-amount-condition.dto.ts
@@ -1,0 +1,7 @@
+export class GetCategoriesWithTotalAmountCondition {
+  userId: string;
+  startDate: number;
+  endDate: number;
+  minAmount?: number;
+  maxAmount?: number;
+}

--- a/src/api/expense/dto/get-expense-detail-response-data.dto.ts
+++ b/src/api/expense/dto/get-expense-detail-response-data.dto.ts
@@ -1,0 +1,33 @@
+import { Exclude, Expose, plainToInstance, Type } from 'class-transformer';
+import { Expense } from '../../../entity/expense.entity';
+
+@Exclude()
+export class GetExpenseDetailResponseData {
+  @Expose()
+  id: number;
+
+  @Expose()
+  categoryId: number;
+
+  @Expose()
+  content: string;
+
+  @Expose()
+  amount: number;
+
+  @Expose()
+  expenseDate: Date;
+
+  @Expose()
+  isExcluded: boolean;
+
+  @Expose()
+  createdAt: Date;
+
+  @Expose()
+  updatedAt: Date;
+
+  static of(expense: Expense): GetExpenseDetailResponseData {
+    return plainToInstance(GetExpenseDetailResponseData, expense);
+  }
+}

--- a/src/api/expense/dto/get-expenses-condition.dto.ts
+++ b/src/api/expense/dto/get-expenses-condition.dto.ts
@@ -1,0 +1,8 @@
+export class GetExpensesCondition {
+  userId: string;
+  startDate: number;
+  endDate: number;
+  categoryId?: number;
+  minAmount?: number;
+  maxAmount?: number;
+}

--- a/src/api/expense/dto/get-expenses-list-reponse-data.dto.ts
+++ b/src/api/expense/dto/get-expenses-list-reponse-data.dto.ts
@@ -1,0 +1,62 @@
+import { Exclude, Expose, plainToInstance, Transform } from 'class-transformer';
+import { Expense } from '../../../entity/expense.entity';
+import { Category } from '../../../entity/category.entity';
+
+@Exclude()
+export class GetExpensesListResponseData {
+  @Expose()
+  totalAmount: number;
+
+  @Expose()
+  totalAmountByCategory: CategoryWithTotalAmount[];
+
+  @Expose()
+  expenses: PartialExpense[];
+
+  static of(expenses: Expense[], Categories: Category[]) {
+    const getExpensesListResponseData = new GetExpensesListResponseData();
+    getExpensesListResponseData.totalAmount = expenses.reduce(
+      (acc, expense) => (acc += expense.amount),
+      0,
+    );
+    getExpensesListResponseData.totalAmountByCategory = plainToInstance(
+      CategoryWithTotalAmount,
+      Categories,
+    );
+    getExpensesListResponseData.expenses = plainToInstance(
+      PartialExpense,
+      expenses,
+    );
+    return getExpensesListResponseData;
+  }
+}
+
+class CategoryWithTotalAmount {
+  @Expose()
+  id: number;
+
+  @Expose()
+  name: number;
+
+  @Expose()
+  totalAmount: number;
+}
+
+@Exclude()
+class PartialExpense {
+  @Expose()
+  id: number;
+
+  @Expose()
+  content: number;
+
+  @Expose()
+  amount: number;
+
+  @Expose()
+  expenseDate: string;
+
+  @Expose({ name: 'category' })
+  @Transform(({ value }) => value.name) // 카테고리 이름만 추출
+  categoryName: string;
+}

--- a/src/api/expense/dto/get-expenses-list-request-query.dto.ts
+++ b/src/api/expense/dto/get-expenses-list-request-query.dto.ts
@@ -1,0 +1,88 @@
+import {
+  IsDate,
+  IsDefined,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  Validate,
+  ValidateIf,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { GetExpensesCondition } from './get-expenses-condition.dto';
+import { BadRequestException } from '@nestjs/common';
+import { GetCategoriesWithTotalAmountCondition } from './get-categories-with-total-amount-condition.dto';
+
+export class GetExpensesListRequestQuery {
+  @Type(() => Date)
+  @IsDate()
+  startDate: number;
+
+  @Type(() => Date)
+  @IsDate()
+  endDate: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  categoryId?: number;
+
+  @ValidateIf((o) => o.maxAmount !== undefined)
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1000)
+  minAmount?: number;
+
+  @ValidateIf((o) => o.minAmount !== undefined)
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  maxAmount?: number;
+
+  toGetExpensesCondition(userId: string): GetExpensesCondition {
+    const getExpensesCondition = new GetExpensesCondition();
+    getExpensesCondition.userId = userId;
+    getExpensesCondition.startDate = this.startDate;
+    getExpensesCondition.endDate = this.endDate;
+    getExpensesCondition.categoryId = this.categoryId;
+
+    if (
+      (!this.minAmount && this.maxAmount) ||
+      (this.minAmount && !this.maxAmount)
+    ) {
+      throw new BadRequestException(
+        'minAmount와 maxAmount는 함께 포함되어야 합니다.',
+      );
+    }
+
+    if (this.minAmount > this.maxAmount) {
+      throw new BadRequestException('minAmount는 maxAmount보다 작아야 합니다.');
+    }
+
+    if (this.minAmount && this.maxAmount) {
+      getExpensesCondition.maxAmount = this.maxAmount;
+      getExpensesCondition.minAmount = this.minAmount;
+    }
+
+    return getExpensesCondition;
+  }
+
+  toGetCategoriesWithTotalAmountCondition(
+    userId: string,
+  ): GetCategoriesWithTotalAmountCondition {
+    const getCategoriesWithTotalAmountCondition =
+      new GetCategoriesWithTotalAmountCondition();
+    getCategoriesWithTotalAmountCondition.userId = userId;
+    getCategoriesWithTotalAmountCondition.startDate = this.startDate;
+    getCategoriesWithTotalAmountCondition.endDate = this.endDate;
+
+    if (this.minAmount && this.maxAmount) {
+      getCategoriesWithTotalAmountCondition.maxAmount = this.maxAmount;
+      getCategoriesWithTotalAmountCondition.minAmount = this.minAmount;
+    }
+    return getCategoriesWithTotalAmountCondition;
+  }
+}

--- a/src/api/expense/dto/update-expense-response-data.dto.ts
+++ b/src/api/expense/dto/update-expense-response-data.dto.ts
@@ -1,15 +1,5 @@
-import { Exclude, Expose, plainToInstance, Type } from 'class-transformer';
+import { Exclude, Expose, plainToInstance } from 'class-transformer';
 import { Expense } from '../../../entity/expense.entity';
-import {
-  IsBoolean,
-  IsDate,
-  IsNumber,
-  IsOptional,
-  IsString,
-  Max,
-  MaxLength,
-  Min,
-} from 'class-validator';
 
 @Exclude()
 export class UpdateExpenseResponseData {

--- a/src/api/expense/expense.controller.ts
+++ b/src/api/expense/expense.controller.ts
@@ -8,12 +8,15 @@ import {
   Delete,
   UseGuards,
   Req,
+  Query,
 } from '@nestjs/common';
 
 import { CreateExpenseRequestBody } from './dto/create-expense-request-body.dto';
 import { CreateExpenseResponseData } from './dto/create-expense-response-data.dto';
 import { UpdateExpenseResponseData } from './dto/update-expense-response-data.dto';
 import { UpdateExpenseRequestBody } from './dto/update-expense-request-body.dto';
+import { GetExpensesListRequestQuery } from './dto/get-expenses-list-request-query.dto';
+import { GetExpenseDetailResponseData } from './dto/get-expense-detail-response-data.dto';
 
 import { ExpenseService } from './service/expense.service';
 
@@ -21,7 +24,7 @@ import { SuccessMessage } from '../../shared/enum/success-message.enum';
 import { RequestWithUser } from '../../shared/interface/request-with-user.interfact';
 import { JwtAuthGuard } from '../../shared/guard/jwt-auth.guard';
 import { OwnExpenseGuard } from './guard/own-expense.guard';
-import { GetExpenseDetailResponseData } from './dto/get-expense-detail-response-data.dto';
+import { GetExpensesListResponseData } from './dto/get-expenses-list-reponse-data.dto';
 
 @UseGuards(JwtAuthGuard)
 @Controller('expenses')
@@ -64,8 +67,22 @@ export class ExpenseController {
   }
 
   @Get()
-  findAll() {
-    return 'GET /expenses';
+  async getExpensesList(
+    @Req() req: RequestWithUser,
+    @Query() dto: GetExpensesListRequestQuery,
+  ) {
+    const expenses = await this.expenseService.getExpensesWithCondition(
+      dto.toGetExpensesCondition(req.user.id),
+    );
+
+    const categoriesWithTotalAmount =
+      await this.expenseService.getCategoriesWithTotalAmount(
+        dto.toGetCategoriesWithTotalAmountCondition(req.user.id),
+      );
+    return {
+      message: SuccessMessage.EXPENSE_GET_LIST,
+      data: GetExpensesListResponseData.of(expenses, categoriesWithTotalAmount),
+    };
   }
 
   @UseGuards(OwnExpenseGuard)

--- a/src/api/expense/expense.controller.ts
+++ b/src/api/expense/expense.controller.ts
@@ -12,7 +12,7 @@ import {
 
 import { CreateExpenseRequestBody } from './dto/create-expense-request-body.dto';
 import { CreateExpenseResponseData } from './dto/create-expense-response-data.dto';
-import { UpdateExpenseResponseData } from './dto/update-expense-response-body.dto';
+import { UpdateExpenseResponseData } from './dto/update-expense-response-data.dto';
 import { UpdateExpenseRequestBody } from './dto/update-expense-request-body.dto';
 
 import { ExpenseService } from './service/expense.service';
@@ -21,6 +21,7 @@ import { SuccessMessage } from '../../shared/enum/success-message.enum';
 import { RequestWithUser } from '../../shared/interface/request-with-user.interfact';
 import { JwtAuthGuard } from '../../shared/guard/jwt-auth.guard';
 import { OwnExpenseGuard } from './guard/own-expense.guard';
+import { GetExpenseDetailResponseData } from './dto/get-expense-detail-response-data.dto';
 
 @UseGuards(JwtAuthGuard)
 @Controller('expenses')
@@ -69,8 +70,13 @@ export class ExpenseController {
 
   @UseGuards(OwnExpenseGuard)
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return 'GET /expenses/:id';
+  async getExpenseDetail(@Param('id') id: number) {
+    const expense = await this.expenseService.getExpenseById(id);
+
+    return {
+      message: SuccessMessage.EXPENSE_GET_DETAIL,
+      data: GetExpenseDetailResponseData.of(expense),
+    };
   }
 
   @UseGuards(OwnExpenseGuard)

--- a/src/api/expense/service/expense.service.ts
+++ b/src/api/expense/service/expense.service.ts
@@ -3,11 +3,13 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
 import { CreateExpenseResource } from '../dto/create-expense-resource.dto';
+import { UpdateExpenseResource } from '../dto/update-expense-resource.dto';
+import { GetExpensesCondition } from '../dto/get-expenses-condition.dto';
+import { GetCategoriesWithTotalAmountCondition } from '../dto/get-categories-with-total-amount-condition.dto';
 
 import { Expense } from '../../../entity/expense.entity';
 import { Category } from '../../../entity/category.entity';
 import { FailMessage } from '../../../shared/enum/fail-message.enum';
-import { UpdateExpenseResource } from '../dto/update-expense-resource.dto';
 
 @Injectable()
 export class ExpenseService {
@@ -15,7 +17,7 @@ export class ExpenseService {
     @InjectRepository(Expense)
     private readonly expenseRepo: Repository<Expense>,
     @InjectRepository(Category)
-    private readonly categoryRepo: Repository<Expense>,
+    private readonly categoryRepo: Repository<Category>,
   ) {}
 
   async createExpenseData(dto: CreateExpenseResource): Promise<Expense> {
@@ -43,6 +45,74 @@ export class ExpenseService {
     }
 
     await this.expenseRepo.update({ id }, dto);
+  }
+
+  getExpensesWithCondition({
+    userId,
+    startDate,
+    categoryId,
+    endDate,
+    minAmount,
+    maxAmount,
+  }: GetExpensesCondition): Promise<Expense[]> {
+    const query = this.expenseRepo
+      .createQueryBuilder('e')
+      .select() // 지출 모든 컬럼 조회
+      .addSelect('c.id')
+      .addSelect('c.name')
+      .innerJoin('e.category', 'c')
+      .where('e.userId = :userId', { userId })
+      .andWhere('e.isExcluded = false')
+      .andWhere('(e.expenseDate >= :startDate AND e.expenseDate <= :endDate)', {
+        startDate,
+        endDate,
+      });
+
+    if (categoryId) {
+      query.andWhere('e.categoryId = :categoryId', { categoryId });
+    }
+
+    if (minAmount && maxAmount) {
+      query.andWhere('(e.amount >= :minAmount AND e.amount <= :maxAmount)', {
+        minAmount,
+        maxAmount,
+      });
+    }
+
+    return query
+      .orderBy('e.expenseDate', 'DESC') // 최신 지출 순
+      .getMany();
+  }
+
+  getCategoriesWithTotalAmount({
+    userId,
+    startDate,
+    endDate,
+    minAmount,
+    maxAmount,
+  }: GetCategoriesWithTotalAmountCondition): Promise<Category[]> {
+    const query = this.categoryRepo
+      .createQueryBuilder('c')
+      .select('c.id', 'id')
+      .addSelect('c.name', 'name')
+      .addSelect('SUM(e.amount)', 'totalAmount')
+      .innerJoin('expenses', 'e', 'e.categoryId = c.id')
+      .where('e.userId = :userId', { userId })
+      .andWhere('e.isExcluded = false')
+      .andWhere('(e.expenseDate >= :startDate AND e.expenseDate <= :endDate)', {
+        startDate,
+        endDate,
+      });
+
+    if (minAmount && maxAmount) {
+      query.andWhere('(e.amount >= :minAmount AND e.amount <= :maxAmount)', {
+        minAmount,
+        maxAmount,
+      });
+    }
+    return query
+      .groupBy('c.id') //
+      .getRawMany();
   }
 
   getExpenseById(id: number): Promise<Expense> {

--- a/src/shared/enum/success-message.enum.ts
+++ b/src/shared/enum/success-message.enum.ts
@@ -6,6 +6,7 @@ export enum SuccessMessage {
   BUDGET_SET_MONTHLY = '월별 예산 설정 성공했습니다.',
   BUDGET_GET_RECOMMENDATION = '월별 예산 추천 성공했습니다.',
   EXPENSE_CREATE = '지출 생성 성공했습니다.',
+  EXPENSE_GET_DETAIL = '지출 상세 조회 성공했습니다.',
   EXPENSE_UPDATE = '지출 수정 성공했습니다.',
   EXPENSE_DELETE = '지출 삭제 성공했습니다.',
 }

--- a/src/shared/enum/success-message.enum.ts
+++ b/src/shared/enum/success-message.enum.ts
@@ -6,6 +6,7 @@ export enum SuccessMessage {
   BUDGET_SET_MONTHLY = '월별 예산 설정 성공했습니다.',
   BUDGET_GET_RECOMMENDATION = '월별 예산 추천 성공했습니다.',
   EXPENSE_CREATE = '지출 생성 성공했습니다.',
+  EXPENSE_GET_LIST = '지출 목록 조회 성공했습니다.',
   EXPENSE_GET_DETAIL = '지출 상세 조회 성공했습니다.',
   EXPENSE_UPDATE = '지출 수정 성공했습니다.',
   EXPENSE_DELETE = '지출 삭제 성공했습니다.',


### PR DESCRIPTION
## 🚀 이슈 번호
https://github.com/dawwson/budget-keeper-be/issues/12#issue-1989468778
<br>

## 💡 변경 이유
- 기능 추가
<br>

## 🔑 주요 변경사항
- 지출 합계 + 카테고리별 지출 합계를 포함한 기간별 지출 목록 조회
  - 카테고리, 지출 금액 구간 필터링
  - 지출 합계는 지출 목록을 조회한 후 amount 값을 합침
  - 카테고리별 지출 합계는 SUM() 집계함수 + GROUP BY 사용하여 쿼리로 조회
<br>

## 📷 테스트 결과
<img width="945" alt="image" src="https://github.com/dawwson/budget-keeper-be/assets/45624238/09b7fc5f-e994-4767-b9ea-6b1e7f97e62b">
