### PR TITLE
지출 통계 API

### DIFF
--- a/src/api/expense/dto/get-expenses-list-request-query.dto.ts
+++ b/src/api/expense/dto/get-expenses-list-request-query.dto.ts
@@ -14,6 +14,7 @@ import { Type } from 'class-transformer';
 import { GetExpensesCondition } from './get-expenses-condition.dto';
 import { BadRequestException } from '@nestjs/common';
 import { GetCategoriesWithTotalAmountCondition } from './get-categories-with-total-amount-condition.dto';
+import { FailMessage } from '../../../shared/enum/fail-message.enum';
 
 export class GetExpensesListRequestQuery {
   @Type(() => Date)
@@ -54,12 +55,14 @@ export class GetExpensesListRequestQuery {
       (this.minAmount && !this.maxAmount)
     ) {
       throw new BadRequestException(
-        'minAmount와 maxAmount는 함께 포함되어야 합니다.',
+        FailMessage.EXPENSE_MIN_MAX_AMOUNT_EXCLUSIVE,
       );
     }
 
     if (this.minAmount > this.maxAmount) {
-      throw new BadRequestException('minAmount는 maxAmount보다 작아야 합니다.');
+      throw new BadRequestException(
+        FailMessage.EXPENSE_MIN_AMOUNT_MORE_THAN_MAX,
+      );
     }
 
     if (this.minAmount && this.maxAmount) {

--- a/src/api/expense/expense.controller.ts
+++ b/src/api/expense/expense.controller.ts
@@ -91,28 +91,32 @@ export class ExpenseController {
 
   @Get('statistics')
   async getExpenseStatistics(@Req() req: RequestWithUser) {
-    const { lastMonthAmount, thisMonthAmount } =
+    // 지난달, 이번달 카테고리별 지출 합계
+    const monthStatisticsByCategory =
       await this.statisticsExpenseService.compareLastMonthWithThisMonth(
         req.user.id,
       );
 
-    const { lastWeekAmount, thisWeekAmount } =
+    // 7일 전, 오늘 카테고리별 지출 합계
+    const weekStatisticsByCategory =
       await this.statisticsExpenseService.compareLastWeekWithThisWeek(
         req.user.id,
       );
     return {
       message: '성공',
       data: {
-        comparedToLastMonth: {
-          // null이면 0, 아니면 number로 변환
-          lastMonthAmount: Number(lastMonthAmount),
-          thisMonthAmount: Number(thisMonthAmount),
-        },
-        comparedToLast: {
-          // null이면 0, 아니면 number로 변환
-          lastWeekAmount: Number(lastWeekAmount),
-          thisWeekAmount: Number(thisWeekAmount),
-        },
+        comparedToLastMonth: monthStatisticsByCategory.map((statistic) => ({
+          ...statistic,
+          // string -> number로 변환
+          lastMonthAmount: Number(statistic.lastMonthAmount),
+          thisMonthAmount: Number(statistic.thisMonthAmount),
+        })),
+        comparedToLastWeek: weekStatisticsByCategory.map((statistic) => ({
+          ...statistic,
+          // string -> number로 변환
+          lastWeekAmount: Number(statistic.lastWeekAmount),
+          thisWeekAmount: Number(statistic.thisWeekAmount),
+        })),
       },
     };
   }

--- a/src/api/expense/expense.controller.ts
+++ b/src/api/expense/expense.controller.ts
@@ -103,7 +103,7 @@ export class ExpenseController {
         req.user.id,
       );
     return {
-      message: '성공',
+      message: SuccessMessage.EXPENSE_GET_STATISTICS,
       data: {
         comparedToLastMonth: monthStatisticsByCategory.map((statistic) => ({
           ...statistic,

--- a/src/api/expense/expense.module.ts
+++ b/src/api/expense/expense.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { ExpenseService } from './service/expense.service';
+import { StatisticsExpenseService } from './service/statistics-expense.service';
 import { ExpenseController } from './expense.controller';
 
 import { Expense } from '../../entity/expense.entity';
@@ -11,7 +12,7 @@ import { ExpenseLib } from './service/expense.lib';
 @Module({
   imports: [TypeOrmModule.forFeature([Expense, Category])],
   controllers: [ExpenseController],
-  providers: [ExpenseService, ExpenseLib],
+  providers: [ExpenseService, StatisticsExpenseService, ExpenseLib],
   exports: [ExpenseLib],
 })
 export class ExpenseModule {}

--- a/src/api/expense/service/statistics-expense.service.ts
+++ b/src/api/expense/service/statistics-expense.service.ts
@@ -31,15 +31,18 @@ export class StatisticsExpenseService {
         // 지난 달 지출 합계
         .addSelect(
           // NOTE: 지난 달에 해당하는 지출만 집계에 포함시킵니다.
+          // COALESCE : NULL -> 0으로 변환
           'COALESCE(SUM(e.amount) FILTER(WHERE EXTRACT(MONTH FROM e.expenseDate) = EXTRACT(MONTH FROM CURRENT_DATE) - 1), 0)',
           'lastMonthAmount',
         )
         // 이번 달 지출 합계
         .addSelect(
           // NOTE: 이번 달에 해당하는 지출만 집계에 포함시킵니다.
+          // COALESCE : NULL -> 0으로 변환
           'COALESCE(SUM(amount) FILTER(WHERE EXTRACT(MONTH FROM expense_date) = EXTRACT(MONTH FROM CURRENT_DATE)), 0)',
           'thisMonthAmount',
         )
+        // NOTE: 카테고리 테이블 기준으로 모든 행 보존하면서 조건에 따라 지출 테이블 값을 가져옵니다.
         .leftJoin(
           'expenses',
           'e',
@@ -75,9 +78,11 @@ export class StatisticsExpenseService {
         // 오늘 지출 합계
         .addSelect(
           // NOTE: 오늘에 해당하는 row만 집계에 포함시킵니다.
+          // COALESCE : NULL -> 0으로 변환
           'COALESCE(SUM(e.amount) FILTER(WHERE EXTRACT(DAY FROM expense_date) = EXTRACT(DAY FROM CURRENT_DATE)), 0)',
           'thisWeekAmount',
         )
+        // NOTE: 카테고리 테이블 기준으로 모든 행 보존하면서 조건에 따라 지출 테이블 값을 가져옵니다.
         .leftJoin(
           'expenses',
           'e',

--- a/src/api/expense/service/statistics-expense.service.ts
+++ b/src/api/expense/service/statistics-expense.service.ts
@@ -1,0 +1,66 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { Expense } from '../../../entity/expense.entity';
+import { Category } from '../../../entity/category.entity';
+
+@Injectable()
+export class StatisticsExpenseService {
+  constructor(
+    @InjectRepository(Expense)
+    private readonly expenseRepo: Repository<Expense>,
+    @InjectRepository(Category)
+    private readonly categoryRepo: Repository<Category>,
+  ) {}
+
+  compareLastMonthWithThisMonth(userId: string): Promise<{
+    lastMonthAmount: string | null;
+    thisMonthAmount: string | null;
+  }> {
+    return (
+      this.expenseRepo
+        .createQueryBuilder('e')
+        // 지난 달 지출 합계
+        .select(
+          // NOTE: 지난 달에 해당하는 지출만 집계에 포함시킵니다.
+          'SUM(e.amount) FILTER(WHERE EXTRACT(MONTH FROM e.expenseDate) = EXTRACT(MONTH FROM CURRENT_DATE) - 1)',
+          'lastMonthAmount',
+        )
+        // 이번 달 지출 합계
+        .addSelect(
+          // NOTE: 이번 달에 해당하는 지출만 집계에 포함시킵니다.
+          'SUM(amount) FILTER(WHERE EXTRACT(MONTH FROM expense_date) = EXTRACT(MONTH FROM CURRENT_DATE))',
+          'thisMonthAmount',
+        )
+        .where('e.userId = :userId', { userId })
+        .andWhere('e.isExcluded = false')
+        .getRawOne()
+    );
+  }
+
+  compareLastWeekWithThisWeek(userId: string): Promise<{
+    lastWeekAmount: string | null;
+    thisWeekAmount: string | null;
+  }> {
+    return (
+      this.expenseRepo
+        .createQueryBuilder('e')
+        // 지난 달 지출 합계
+        .select(
+          // NOTE: 지난 주 오늘(7일 전)에 해당하는 row만 집계에 포함시킵니다.
+          "SUM(e.amount) FILTER(WHERE EXTRACT(DAY FROM e.expenseDate) = EXTRACT(DAY FROM CURRENT_DATE - interval '7 days'))",
+          'lastWeekAmount',
+        )
+        // 이번 달 지출 합계
+        .addSelect(
+          // NOTE: 오늘에 해당하는 row만 집계에 포함시킵니다.
+          'SUM(e.amount) FILTER(WHERE EXTRACT(DAY FROM expense_date) = EXTRACT(DAY FROM CURRENT_DATE))',
+          'thisWeekAmount',
+        )
+        .where('e.userId = :userId', { userId })
+        .andWhere('e.isExcluded = false')
+        .getRawOne()
+    );
+  }
+}

--- a/src/api/expense/service/statistics-expense.service.ts
+++ b/src/api/expense/service/statistics-expense.service.ts
@@ -46,8 +46,6 @@ export class StatisticsExpenseService {
           'c.id = e.category_id AND e.userId = :userId AND e.isExcluded = false',
           { userId },
         )
-        // .where('e.userId = :userId', { userId })
-        // .andWhere('e.isExcluded = false')
         .groupBy('c.id')
         .orderBy('c.id', 'ASC')
         .getRawMany()
@@ -89,22 +87,6 @@ export class StatisticsExpenseService {
         .groupBy('c.id')
         .orderBy('c.id', 'ASC')
         .getRawMany()
-      /*
-      select
-  c.id,
-  c.name,
-  SUM(e.amount) FILTER(WHERE EXTRACT(DAY FROM expense_date) = EXTRACT(DAY FROM CURRENT_DATE - interval '7 days')) AS lastWeekAmount,
-  SUM(e.amount) FILTER(WHERE EXTRACT(DAY FROM expense_date) = EXTRACT(DAY FROM CURRENT_DATE)) AS thisWeekAmount
-FROM
-  categories c
-inner join
-  expenses e
-  on c.id = e.category_id
-WHERE
-  e.user_id = 'c09b51ca-3116-4abd-a804-ab22315d4d1f'
-  and e.is_excluded = false
-group by c.id;
-       */
     );
   }
 }

--- a/src/shared/enum/fail-message.enum.ts
+++ b/src/shared/enum/fail-message.enum.ts
@@ -7,4 +7,6 @@ export enum FailMessage {
   USER_PASSWORD_IS_WRONG = '비밀번호가 일치하지 않습니다.',
   EXPENSE_INVALID_CATEGORY_ID = '카테고리 ID가 유효하지 않습니다.',
   EXPENSE_NOT_FOUND = '지출이 존재하지 않습니다.',
+  EXPENSE_MIN_MAX_AMOUNT_EXCLUSIVE = 'minAmount와 maxAmount는 함께 포함되어야 합니다.',
+  EXPENSE_MIN_AMOUNT_MORE_THAN_MAX = 'minAmount는 maxAmount보다 작아야 합니다.',
 }

--- a/src/shared/enum/success-message.enum.ts
+++ b/src/shared/enum/success-message.enum.ts
@@ -10,4 +10,5 @@ export enum SuccessMessage {
   EXPENSE_GET_DETAIL = '지출 상세 조회 성공했습니다.',
   EXPENSE_UPDATE = '지출 수정 성공했습니다.',
   EXPENSE_DELETE = '지출 삭제 성공했습니다.',
+  EXPENSE_GET_STATISTICS = '지출 통계 조회 성공했습니다.',
 }


### PR DESCRIPTION
## 🚀 이슈 번호
https://github.com/dawwson/budget-keeper-be/issues/14#issue-1989469468
<br>

## 💡 변경 이유
- 기능 추가
<br>

## 🔑 주요 변경사항
- 지난달, 이번달 카테고리별 지출 합계 + 7일 전, 오늘 카테고리별 지출 합계 조회
- 통계 비즈니스를 위한 별도의 서비스 분리
- 새롭게 적용해본 postgreSQL window 함수 : COALESCE
  - NULL에 대한 디폴트값을 설정해 NULL 값을 방지해줌
- userId = 'xxx', isExcluded = false 조건을 Where 절에서 On절로 옮김 + inner join에서 left join으로 변경
  - 카테고리 테이블을 유지하면서 지출 테이블의 합계 결과를 가져오기 위함(모든 카테고리별 지출 합계 조회를 하기 위해서)
<br>

## 📷 테스트 결과
<img width="911" alt="image" src="https://github.com/dawwson/budget-keeper-be/assets/45624238/1c70964d-9f04-4079-95de-ebe0bfc62b84">
<img width="873" alt="image" src="https://github.com/dawwson/budget-keeper-be/assets/45624238/edbb8f11-2a87-4bd9-9291-c50cf166d46e">
