### PR TITLE
users 테이블 id가 자동 생성된 UUID로 적용 안 되는 문제 수정

### DIFF
--- a/src/entity/user.entity.ts
+++ b/src/entity/user.entity.ts
@@ -3,15 +3,14 @@ import {
   Column,
   CreateDateColumn,
   Entity,
-  PrimaryColumn,
+  PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
-import { v4 as uuid } from 'uuid';
 import * as bcrypt from 'bcrypt';
 
 @Entity('users')
 export class User {
-  @PrimaryColumn({ type: 'uuid', default: uuid() })
+  @PrimaryGeneratedColumn('uuid')
   id: string;
 
   @Column({ type: 'varchar', length: 100, unique: true })

--- a/test/in-memory-testing/in-memory-testing.module.ts
+++ b/test/in-memory-testing/in-memory-testing.module.ts
@@ -17,7 +17,8 @@ import serverConfig from '../../src/config/server.config';
       load: [dbConfig, serverConfig],
       isGlobal: true,
     }),
-    TypeOrmModule.forRoot(), // NOTE: TypeORM DataSource를 프로바이더로 등록됩니다. 세부 옵션은 setup.ts에서 설정합니다.
+    // NOTE: TypeORM DataSource를 프로바이더로 등록됩니다. 세부 옵션은 initialize-data-source.ts에서 설정합니다.
+    TypeOrmModule.forRoot(),
     AuthModule,
     CategoryModule,
     BudgetModule,

--- a/test/in-memory-testing/setup-memory-db.ts
+++ b/test/in-memory-testing/setup-memory-db.ts
@@ -1,4 +1,5 @@
-import { newDb, IMemoryDb } from 'pg-mem';
+import { newDb, IMemoryDb, DataType } from 'pg-mem';
+import { v4 } from 'uuid';
 
 export const setupMemoryDb = (): IMemoryDb => {
   const db = newDb({
@@ -18,6 +19,16 @@ export const setupMemoryDb = (): IMemoryDb => {
     name: 'current_database',
     // 쿼리 결과
     implementation: () => 'test',
+  });
+
+  // CREATE EXTENSION IF NOT EXISTS "uuid-ossp"
+  db.registerExtension('uuid-ossp', (schema) => {
+    schema.registerFunction({
+      name: 'uuid_generate_v4',
+      returns: DataType.uuid,
+      implementation: v4,
+      impure: true,
+    });
   });
 
   return db;


### PR DESCRIPTION
## 🚀 이슈 번호
https://github.com/dawwson/budget-keeper-be/issues/27#issue-2010678865
<br>

## 💡 변경 이유
- 회원가입 시 동작하는 user 엔티티에 대한 .save() 실행 시 PK 중복으로 인해 회원가입 실패하는 문제 발생

<br>

## 🔑 주요 변경사항
- id 프로퍼티에 대한 데코레이터를 변경
  - @PrimaryColumn({ type: 'uuid', default: () => uuid() }) => @PrimaryGeneratedColumn('uuid')
- 테스트 코드에서 in-memory db 설정시 관련된 쿼리 실행되도록 수정
  - CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
  - CREATE TABLE "users" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), ... );
<br>

## 📷 테스트 결과
- synchronize: true로 설정 후 테이블 생성시 쿼리가 변경된 것 확인
<img width="505" alt="image" src="https://github.com/dawwson/budget-keeper-be/assets/45624238/151cd186-b3d0-46a8-b7d6-a593fdd9cc79">
<img width="797" alt="image" src="https://github.com/dawwson/budget-keeper-be/assets/45624238/0063187e-3d99-4063-a692-18c68b9b1985">
